### PR TITLE
Support LaTeX output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,14 +4,15 @@ sphinxcontrib-details-directive
 
 ``details`` directive for Sphinx
 
-It enables ``details`` directive as an element to represent ``<details>`` element in HTML output.
-It will be converted into mere paragraphs in other output formats.
+It enables ``details`` directive as an element to represent ``<details>``
+element in HTML output. LaTeX output is via the ``sphinxdetails``
+environment and ``\sphinxdetailssummary`` macro. In other output formats, the
+directive contents are rendered as plain paragraphs.
 
 Install
 =======
 
 Install the package via pip::
-
 
   $ pip install sphinxcontrib-details-directive
 
@@ -23,14 +24,19 @@ Directive
 =========
 
 **details**
-  ``details`` directive create a ``<details>`` block containing following contents::
+  The ``details`` directive creates a ``<details>`` block containing following contents::
 
     .. details:: summary of the detail block
 
        description of the details block.
        blah blah blah
 
-  It will be rendered with ``<details>`` tag in HTML output.  On the other hand, for
-  other output formats, it will be rendered as mere paragraphs.
+  It will be rendered with a ``<details>`` tag in HTML output. In LaTeX output,
+  the contents of the directive will be wrapped in a ``sphinxdetails``
+  environment. The summary, if present, will be rendered as the argument to a
+  ``\sphinxdetailssummary`` macro. Customisation can be achieved by defining the
+  environment and/or macro in the preamble. The default is simply to output the
+  contents of the summary and directive. Outputting the summary and contents
+  without further formatting is also the behaviour for all other output formats.
 
   ``:open:`` flag is allowed to indicate the details block is opened by default.

--- a/sphinxcontrib/details/directive/__init__.py
+++ b/sphinxcontrib/details/directive/__init__.py
@@ -43,15 +43,15 @@ def depart_summary(self, node):
 
 
 def visit_details_latex(self, node):
-    if "sphinxdetails" not in self.elements["preamble"]:
+    if "newenvironment{sphinxdetails}" not in self.elements["preamble"]:
         self.elements["preamble"] += \
-            "\n\\newenvironment{sphinxdetails}[1]{}{}\n"
+            "\n\\newenvironment{sphinxdetails}{}{}\n"
 
-    self.body.append("\n\\bgroup\\begin{sphinxdetails}\n")
+    self.body.append("\n\\begin{sphinxdetails}\n")
 
 
 def depart_details_latex(self, node):
-    self.body.append("\\end{sphinxdetails}\\egroup\n")
+    self.body.append("\\end{sphinxdetails}\n")
 
 
 def visit_summary_latex(self, node):

--- a/sphinxcontrib/details/directive/__init__.py
+++ b/sphinxcontrib/details/directive/__init__.py
@@ -42,6 +42,30 @@ def depart_summary(self, node):
     self.body.append('</summary>')
 
 
+def visit_details_latex(self, node):
+    if "sphinxdetails" not in self.elements["preamble"]:
+        self.elements["preamble"] += \
+            "\n\\newenvironment{sphinxdetails}[1]{}{}\n"
+
+    self.body.append("\n\\bgroup\\begin{sphinxdetails}\n")
+
+
+def depart_details_latex(self, node):
+    self.body.append("\\end{sphinxdetails}\\egroup\n")
+
+
+def visit_summary_latex(self, node):
+    if "sphinxdetailssummary" not in self.elements["preamble"]:
+        self.elements["preamble"] += \
+            "\n\\newcommand{\\sphinxdetailssummary}[1]{#1}\n"
+    self.body.append("\\sphinxdetailssummary{")
+
+
+def depart_summary_latex(self, node):
+    self.body.append("}\n")
+
+
+
 class DetailsDirective(Directive):
     required_arguments = 1
     final_argument_whitespace = True
@@ -68,7 +92,7 @@ class DetailsDirective(Directive):
 
 class DetailsTransform(SphinxPostTransform):
     default_priority = 200
-    builders = ('html',)
+    builders = ('html', 'latex')
 
     def run(self):
         matcher = NodeMatcher(nodes.container, type='details')
@@ -80,8 +104,10 @@ class DetailsTransform(SphinxPostTransform):
 
 
 def setup(app):
-    app.add_node(details, html=(visit_details, depart_details))
-    app.add_node(summary, html=(visit_summary, depart_summary))
+    app.add_node(details, html=(visit_details, depart_details),
+                 latex=(visit_details_latex, depart_details_latex))
+    app.add_node(summary, html=(visit_summary, depart_summary),
+                 latex=(visit_summary_latex, depart_summary_latex))
     app.add_directive('details', DetailsDirective)
     app.add_post_transform(DetailsTransform)
 


### PR DESCRIPTION
This PR adds support for custom LaTeX rendering of details directives. This is achieved by wrapping the directive in a `sphinxdetails` environment and the summary, if present, in a `\sphinxdetailssummary` macro.

The documentation is updated accordingly.

The one thing I am not super happy about is the mechanism for inserting the default definitions of the environment and macro into the preamble. I would be very interested if there is a better approach available.