### PR TITLE
Transform all HTML formats

### DIFF
--- a/sphinxcontrib/details/directive/__init__.py
+++ b/sphinxcontrib/details/directive/__init__.py
@@ -68,7 +68,7 @@ class DetailsDirective(Directive):
 
 class DetailsTransform(SphinxPostTransform):
     default_priority = 200
-    builders = ('html',)
+    formats = ('html',)
 
     def run(self):
         matcher = NodeMatcher(nodes.container, type='details')


### PR DESCRIPTION
I noticed the extension does not work when using HTML builders other than 'html', for example 'dirhtml'. This PR makes sure the details directive is transformed for all HTML format builders.