### PR TITLE
removed the pkg_resources dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [build]
-build-base = _build
+build_base = _build
 
 [sdist]
 formats = gztar

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from typing import Dict
 
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, setup
 
 
 def get_long_description():
@@ -44,7 +44,7 @@ setup(
         'Topic :: Documentation :: Sphinx',
         'Topic :: Utilities',
     ],
-    packages=find_packages(),
+    packages=find_namespace_packages(include=['sphinxcontrib.*']),
     install_requires=[
         'Sphinx>=2.0',
     ],
@@ -57,5 +57,4 @@ setup(
             'mypy',
         ],
     },
-    namespace_packages=['sphinxcontrib'],
 )

--- a/sphinxcontrib/__init__.py
+++ b/sphinxcontrib/__init__.py
@@ -1,9 +1,0 @@
-"""
-    sphinxcontrib
-    ~~~~~~~~~~~~~
-
-    :copyright: Copyright 2017-2019 by Takeshi KOMIYA
-    :license: Apache License 2.0, see LICENSE for details.
-"""
-
-__import__('pkg_resources').declare_namespace(__name__)

--- a/sphinxcontrib/details/__init__.py
+++ b/sphinxcontrib/details/__init__.py
@@ -5,5 +5,3 @@
     :copyright: Copyright 2017-2019 by Takeshi KOMIYA
     :license: Apache License 2.0, see LICENSE for details.
 """
-
-__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
Fixes #8 

Changes made in this PR:
- Removed `pkg_resources` from the `__init__.py` files.
- Changed the `setup.cfg` to use [finding-namespace-packages()](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#finding-namespace-packages) as an alternative to  `pkg_resources`
- Changed `build-base` to `build_base` to preempt future [problems](https://github.com/pypa/setuptools/discussions/5011)